### PR TITLE
Fix possibility of non-monotonic id generation after clock adjustment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ docs:
 	@$(REBAR) edoc
 
 test:
-	@$(REBAR) eunit
+	@$(REBAR) do eunit, ct
 
 dialyzer:
 	@$(REBAR) dialyzer

--- a/README.md
+++ b/README.md
@@ -14,12 +14,3 @@ Original design by [Twitter](https://github.com/twitter/snowflake).
 [93,46,42,42,42,53,55,43,42,43,73,36,34,33,39,52,48,39,35,
  54,36,34,33,34,40,35,33,33,34|...]
 ```
-
-# To do #
-
-* Fix for NTP adjustments
-  
-  Sometimes NTP will repeat milliseconds, but this violates the strict
-  ordering of snowflake. Snowflake should keep track of the last seen
-  time and wait until NTP catches back up so as to ensure
-  monotonicity.

--- a/src/sf_snowstorm.erl
+++ b/src/sf_snowstorm.erl
@@ -25,37 +25,27 @@
 	calendar:datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}})).
 -define(MS_EPOCH_DIFF, 1000*(?SNOWFLAKE_EPOCH - ?STD_EPOCH)).
 
--define(TIMESTAMP_SIZE, 42).
--define(MACHINE_ID_SIZE, 10).
--define(COUNTER_SIZE, 12).
-
 %% The gen_server state
--record(st, 
+-record(st,
 	{name :: atom(),
-	 last :: integer(),
-	 machine :: integer(),
-	 count :: integer()}).
+	 gen :: snowflake_gen:state()}).
 
 
 %% --------------------
 %% Gen_Server callbacks
 
 init([Name]) ->
-    {ok, #st{name = Name, last = snowflake_now(),
-	     count = 0, machine = machine_id()}}.
+	{ok, Gen} = snowflake_gen:new(snowflake_now(), machine_id()),
+    {ok, #st{name = Name, gen = Gen}}.
     
-handle_call(new, _From, State = #st{last = Last, 
-				    machine = MID, 
-				    count = Count}) ->
-    Now = snowflake_now(),
-    SID = case Now of
-	      Last -> Count;
-	      %% New time point, reset the counter.
-	      _    -> 0
-	  end,
-    {reply, 
-     <<Now:?TIMESTAMP_SIZE, MID:?MACHINE_ID_SIZE, SID:?COUNTER_SIZE>>, 
-     State#st{last = Now, count = SID+1}}.
+handle_call(new, _From, State = #st{gen = GenSt}) ->
+    {Reply, NewGenSt} = case snowflake_gen:next(snowflake_now(), GenSt) of
+		{ok, ID, St} ->
+			{{ok, ID}, St};
+		{error, _Reason} = Error ->
+			{Error, GenSt}
+	end,
+    {reply, Reply, State#st{gen = NewGenSt}}.
 
 handle_cast(_Message, State) -> {noreply, State}.
 handle_info(_Message, State) -> {noreply, State}.
@@ -97,7 +87,7 @@ machine_id(MID) when is_integer(MID) ->
 	MID;
 machine_id(hostname_hash) ->
 	{ok, Hostname} = inet:gethostname(),
-	erlang:phash2(Hostname, 1 bsl ?MACHINE_ID_SIZE);
+	erlang:phash2(Hostname, 1 bsl snowflake_gen:machine_id_size());
 machine_id({env, Name}) ->
 	case os:getenv(Name) of
 		false ->

--- a/src/sf_snowstorm.erl
+++ b/src/sf_snowstorm.erl
@@ -39,12 +39,7 @@ init([Name]) ->
     {ok, #st{name = Name, gen = Gen}}.
     
 handle_call(new, _From, State = #st{gen = GenSt}) ->
-    {Reply, NewGenSt} = case snowflake_gen:next(snowflake_now(), GenSt) of
-		{ok, ID, St} ->
-			{{ok, ID}, St};
-		{error, _Reason} = Error ->
-			{Error, GenSt}
-	end,
+    {Reply, NewGenSt} = snowflake_gen:next(snowflake_now(), GenSt),
     {reply, Reply, State#st{gen = NewGenSt}}.
 
 handle_cast(_Message, State) -> {noreply, State}.

--- a/src/snowflake.erl
+++ b/src/snowflake.erl
@@ -23,7 +23,7 @@
 %% ----------
 %% Some types
 
--type uuid() :: <<_:64>>.
+-type uuid() :: snowflake_gen:uuid().
 %% A uuid binary consisting of `<<Time, MachineID, SequenceID>>' where
 %% `Time' is a 42 bit binary integer recording milliseconds since UTC
 %% 2012-01-01T00:00:00Z, `MachineID' a 10 bit integer recording the
@@ -51,7 +51,12 @@ new(Name) when is_atom(Name) ->
 	    new(Server, Name)
     end;
 new(Storm) when is_pid(Storm) ->
-    gen_server:call(Storm, new).
+    case gen_server:call(Storm, new) of
+	{ok, ID} ->
+	    ID;
+	{error, Reason} ->
+	    erlang:throw(Reason)
+    end.
 
 -spec
 %% @doc Creates a new snowflake in a named series. Two snowflakes with

--- a/src/snowflake.erl
+++ b/src/snowflake.erl
@@ -55,7 +55,7 @@ new(Storm) when is_pid(Storm) ->
 	{ok, ID} ->
 	    ID;
 	{error, Reason} ->
-	    erlang:throw(Reason)
+	    erlang:error(Reason)
     end.
 
 -spec

--- a/src/snowflake_gen.erl
+++ b/src/snowflake_gen.erl
@@ -1,0 +1,82 @@
+-module(snowflake_gen).
+
+-export([timestamp_size/0]).
+-export([machine_id_size/0]).
+-export([counter_size/0]).
+-export([new/2]).
+-export([next/2]).
+
+-export_type([uuid/0]).
+-export_type([machine_id/0]).
+-export_type([time/0]).
+-export_type([state/0]).
+-export_type([generation_error_reason/0]).
+
+-type uuid() :: <<_:64>>.
+-type machine_id() :: non_neg_integer().
+-type time() :: non_neg_integer().
+-type generation_error_reason() ::
+    {backward_clock_moving, Last :: time(), New :: time()} |
+    {invalid_timestamp, Time :: integer()} |
+    exhausted.
+
+
+-record(state, {
+    last :: time(),
+    machine :: machine_id(),
+    count :: counter()
+}).
+-opaque state() :: state().
+
+%% Internal types
+
+-type counter() :: non_neg_integer().
+
+%% Constants
+
+-define(TIMESTAMP_SIZE, 42).
+-define(MACHINE_ID_SIZE, 10).
+-define(COUNTER_SIZE, 12).
+
+%% API
+
+-spec timestamp_size() -> pos_integer().
+timestamp_size() ->
+    ?TIMESTAMP_SIZE.
+
+-spec machine_id_size() -> pos_integer().
+machine_id_size() ->
+    ?MACHINE_ID_SIZE.
+
+-spec counter_size() -> pos_integer().
+counter_size() ->
+    ?COUNTER_SIZE.
+
+-spec new(time(), machine_id()) ->
+    {ok, state()} |
+    {error, {invalid_machine_id, integer()} | {invalid_timestamp, integer()}}.
+new(Time, _MachineID) when Time >= (1 bsl ?TIMESTAMP_SIZE) orelse Time < 0 ->
+    {error, {invalid_timestamp, Time}};
+new(_Time, MachineID) when MachineID >= (1 bsl ?MACHINE_ID_SIZE) orelse MachineID < 0 ->
+    {error, {invalid_machine_id, MachineID}};
+new(Time, MachineID) ->
+    {ok, #state{
+        machine = MachineID,
+        last = Time,
+        count = 0
+    }}.
+
+-spec next(time(), state()) ->
+    {ok, uuid(), state()} |
+    {error, generation_error_reason()}.
+next(Time, _State) when Time >= (1 bsl ?TIMESTAMP_SIZE) orelse Time < 0 ->
+    {error, {invalid_timestamp, Time}};
+next(Time, #state{last = Last}) when Time < Last ->
+    {error, {backward_clock_moving, Last, Time}};
+next(Time, #state{last = Last} = State) when Time > Last ->
+    next(Time, State#state{last = Time, count = 0});
+next(Time, #state{count = Count, last = Last}) when Time =:= Last andalso Count >= (1 bsl ?COUNTER_SIZE) ->
+    {error, exhausted};
+next(Time, #state{count = Count, last = Last, machine = MachineID} = State) when Time =:= Last ->
+    ID = <<Last:?TIMESTAMP_SIZE, MachineID:?MACHINE_ID_SIZE, Count:?COUNTER_SIZE>>,
+    {ok, ID, State#state{count = Count + 1}}.

--- a/test/snowflake_gen_SUITE.erl
+++ b/test/snowflake_gen_SUITE.erl
@@ -105,5 +105,5 @@ generate_ids(Count, Time, GenSt, Acc) when Count > 0 ->
 
 -spec sf_time() -> time().
 sf_time() ->
-    SnowflakeEPOCH = 1325376000000,  % 1970-01-01T00:00:00Z - 2012-01-01T00:00:00Z in milliseconds
+    SnowflakeEPOCH = 1325376000000,  % 2012-01-01T00:00:00Z - 1970-01-01T00:00:00Z in milliseconds
     os:system_time(millisecond) - SnowflakeEPOCH.

--- a/test/snowflake_gen_SUITE.erl
+++ b/test/snowflake_gen_SUITE.erl
@@ -105,5 +105,5 @@ generate_ids(Count, Time, GenSt, Acc) when Count > 0 ->
 
 -spec sf_time() -> time().
 sf_time() ->
-    SnowflakeEPOCHDiff = 1325376000000,  % 2012-01-01 - 1970-01-01 in milliseconds
-    erlang:system_time(millisecond) - SnowflakeEPOCHDiff.
+    SnowflakeEPOCH = 1325376000000,  % 1970-01-01T00:00:00Z - 2012-01-01T00:00:00Z in milliseconds
+    os:system_time(millisecond) - SnowflakeEPOCH.

--- a/test/snowflake_gen_SUITE.erl
+++ b/test/snowflake_gen_SUITE.erl
@@ -1,0 +1,109 @@
+-module(snowflake_gen_SUITE).
+
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0]).
+
+-export([timestamp_init_validation_test/1]).
+-export([machine_id_init_validation_test/1]).
+-export([timestamp_gen_validation_test/1]).
+-export([monotonic_test/1]).
+-export([backward_clock_moving_test/1]).
+-export([exhausted_test/1]).
+
+-type config() :: [{atom(), term()}].
+-type test_case_name() :: atom().
+-type test_return()    :: _ | no_return().
+
+-type gen() :: snowflake_gen:state().
+-type uuid() :: snowflake_gen:uuid().
+-type time() :: snowflake_gen:time().
+
+-spec all() -> [test_case_name()].
+all() ->
+    [
+        timestamp_init_validation_test,
+        machine_id_init_validation_test,
+        timestamp_gen_validation_test,
+        monotonic_test,
+        backward_clock_moving_test,
+        exhausted_test
+    ].
+
+-spec timestamp_init_validation_test(config()) -> test_return().
+timestamp_init_validation_test(_C) ->
+    TooLittleTime = -1,
+    TooBigTime = 1 bsl snowflake_gen:timestamp_size(),
+    ?assertEqual({error, {invalid_timestamp, TooLittleTime}}, snowflake_gen:new(TooLittleTime, 0)),
+    ?assertEqual({error, {invalid_timestamp, TooBigTime}}, snowflake_gen:new(TooBigTime, 0)).
+
+-spec machine_id_init_validation_test(config()) -> test_return().
+machine_id_init_validation_test(_C) ->
+    TooLittleID = -1,
+    TooBigID = 1 bsl snowflake_gen:timestamp_size(),
+    ?assertEqual({error, {invalid_machine_id, TooLittleID}}, snowflake_gen:new(0, TooLittleID)),
+    ?assertEqual({error, {invalid_machine_id, TooBigID}}, snowflake_gen:new(0, TooBigID)).
+
+-spec timestamp_gen_validation_test(config()) -> test_return().
+timestamp_gen_validation_test(_C) ->
+    {ok, Gen} = snowflake_gen:new(0, 0),
+    TooLittleTime = -1,
+    TooBigTime = 1 bsl snowflake_gen:timestamp_size(),
+    ?assertEqual({error, {invalid_timestamp, TooLittleTime}}, snowflake_gen:next(TooLittleTime, Gen)),
+    ?assertEqual({error, {invalid_timestamp, TooBigTime}}, snowflake_gen:next(TooBigTime, Gen)).
+
+-spec monotonic_test(config()) -> test_return().
+monotonic_test(_C) ->
+    {ok, Gen} = snowflake_gen:new(sf_time(), 0),
+    Time = sf_time(),
+    {_Gen, IDs} = lists:foldl(
+        fun(T, {GenSt, Acc}) ->
+            {ok, Result, NewGenSt} = generate_ids(1 bsl snowflake_gen:counter_size(), T, GenSt),
+            {NewGenSt, Acc ++ Result}
+        end,
+        {Gen, []},
+        [Time, Time + 1, Time + 2, Time + 3]
+    ),
+    ?assertEqual(IDs, lists:sort(uniq(IDs))).
+
+-spec backward_clock_moving_test(config()) -> test_return().
+backward_clock_moving_test(_C) ->
+    Time = sf_time(),
+    NewTime = Time - 1,
+    {ok, Gen} = snowflake_gen:new(Time, 0),
+    ?assertEqual({error, {backward_clock_moving, Time, NewTime}}, snowflake_gen:next(NewTime, Gen)).
+
+-spec exhausted_test(config()) -> test_return().
+exhausted_test(_C) ->
+    {ok, Gen} = snowflake_gen:new(sf_time(), 0),
+    ?assertMatch({error, exhausted, _}, generate_ids((1 bsl snowflake_gen:counter_size()) + 1, sf_time(), Gen)).
+
+%% Utils
+
+-spec uniq(list()) -> list().
+uniq(L) ->
+    sets:to_list(sets:from_list(L)).
+
+-spec generate_ids(non_neg_integer(), time(), gen()) ->
+    {ok, [uuid()], gen()} |
+    {error, snowflake_gen:generation_error_reason(), gen()}.
+generate_ids(Count, Time, GenSt) ->
+    generate_ids(Count, Time, GenSt, []).
+
+-spec generate_ids(non_neg_integer(), time(), gen(), [uuid()]) ->
+    {ok, [uuid()], gen()} |
+    {error, snowflake_gen:generation_error_reason(), gen()}.
+generate_ids(0, _Time, GenSt, Acc) ->
+    {ok, lists:reverse(Acc), GenSt};
+generate_ids(Count, Time, GenSt, Acc) when Count > 0 ->
+    case snowflake_gen:next(Time, GenSt) of
+        {ok, ID, NewGen} ->
+            generate_ids(Count - 1, Time, NewGen, [ID | Acc]);
+        {error, Reason} ->
+            {error, Reason, GenSt}
+    end.
+
+-spec sf_time() -> time().
+sf_time() ->
+    SnowflakeEPOCHDiff = 1325376000000,  % 2012-01-01 - 1970-01-01 in milliseconds
+    erlang:system_time(millisecond) - SnowflakeEPOCHDiff.


### PR DESCRIPTION
Also add checks of of time and machine_id sizes