### PR TITLE
Move warnings_as_errors to dedicated profile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ APP := snowflake
 .PHONY: deps test dialyzer clean distclean
 
 all: deps
-	@$(REBAR) compile
+	@$(REBAR) as strict compile
 
 deps:
 	@$(REBAR) get-deps
@@ -20,7 +20,7 @@ docs:
 	@$(REBAR) edoc
 
 test:
-	@$(REBAR) do eunit, ct
+	@$(REBAR) as test,strict do eunit,ct
 
 dialyzer:
 	@$(REBAR) dialyzer

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,6 @@
 
 {erl_opts, [
     debug_info,
-    warnings_as_errors,
     warn_untyped_record,
     warn_export_vars,
     warn_unused_record,
@@ -41,4 +40,12 @@
         unknown
     ]},
     {plt_apps, all_deps}
+]}.
+
+{profiles, [
+    {strict, [
+        {erl_opts, [
+            warnings_as_errors
+        ]}
+    ]}
 ]}.


### PR DESCRIPTION
The library should not block the compilation of other applications